### PR TITLE
Removing flickering on dark mode.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -20,8 +20,6 @@ function backToTop() {
     window.scrollTo(0, 0);
 }
 
-if (localStorage.getItem('is_darkmode_set') === 'true') enableDarkMode();
-
 document
     .getElementById('darkmode-toggle')
     .addEventListener('click', toggleDarkMode);

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,6 +10,10 @@
     </head>
 
     <body class="bg-white dark:bg-slate-900 transition ease-in-out">
+        <script>
+            const is_dark = localStorage.getItem('is_darkmode_set') === 'true';
+            enableDarkMode();
+        </script>
         <section>
             {% block content %}{% endblock %}
         </section>


### PR DESCRIPTION
When we use darkmode, the screen was flickering whenever we changed pages.

This happened because the page loaded in the default white, then the script loaded and changed the background to dark.

We can avoid that by adding a script in the beginning of the body, which tries to load dark mode before everything else.

Since we added the script in the beginning of the body, we can remove the script from the main.js file.